### PR TITLE
add bigdataviewer-core

### DIFF
--- a/autogen/bundlegroups/org.jdom.xml
+++ b/autogen/bundlegroups/org.jdom.xml
@@ -1,0 +1,16 @@
+
+<!-- jdom bundles-->
+<bundlegroup name="org.jdom">
+	<!-- jdom2 bundle -->
+	<bundle name="jdom2" version="${jdom2.version}">
+		<artifacts>
+			<artifact>
+				<group>org.jdom</group>
+				<id>jdom2</id>
+				<version>${jdom2.version}</version>
+			</artifact>
+		</artifacts>
+		<export>jdom2.*</export>
+	</bundle>
+
+</bundlegroup>

--- a/autogen/bundlegroups/org.scijava.xml
+++ b/autogen/bundlegroups/org.scijava.xml
@@ -124,6 +124,22 @@
 		</dependencies>
 	</bundle>
 
+	<!-- SciJava UI Behaviour-->
+	<bundle name="scijava-ui-behaviour" version="${scijava-ui-behaviour.version}">
+		<artifacts>
+			<artifact>
+				<group>org.scijava</group>
+				<id>scijava-ui-behaviour</id>
+				<version>${scijava-ui-behaviour.version}</version>
+			</artifact>
+		</artifacts>
+		<export>org.scijava.ui.behaviour.*</export>
+		<dependencies>
+			<bundleref name="net.sf.trove4j:trove4j" version="${trove4j.version}" />
+			<bundleref name="com.google.code.gson:gson" version="${gson.version}" />
+		</dependencies>
+	</bundle>
+
 	<!-- SciJava Scripting-Java -->
 	<bundle name="scripting-java" version="${scripting-java.version}">
 		<artifacts>

--- a/autogen/bundlegroups/sc.fiji.xml
+++ b/autogen/bundlegroups/sc.fiji.xml
@@ -16,7 +16,26 @@
 			<bundleref name="net.imglib2:imglib2-realtransform" version="${imglib2-realtransform.version}" />
 			<bundleref name="net.imglib2:imglib2-ui" version="${imglib2-ui.version}" />
 			<bundleref name="net.imglib2:imglib2-algorithm" version="${imglib2-algorithm.version}" />
+			<bundleref name="com.google.code.gson:gson" version="${gson.version}" />
 		</dependencies>
 		<export>bdv.*, net.imglib2.img.basictypeaccess.volatiles.*, net.imglib2.interpolation.randomaccess.*, net.imglib2.type.volatiles.*</export>
+	</bundle>
+
+	<!-- SPIMDATA Bundle -->
+	<bundle name="spim_data" version="${spim_data.version}">
+		<artifacts>
+			<artifact>
+				<group>sc.fiji</group>
+				<id>spim_data</id>
+				<version>${spim_data.version}</version>
+			</artifact>
+		</artifacts>
+		<dependencies>
+			<bundleref name="net.imglib2:imglib2" version="${imglib2.version}" />
+			<bundleref name="net.imglib2:imglib2-realtransform" version="${imglib2-realtransform.version}" />
+			<bundleref name="org.scijava:scijava-common" version="${scijava-common.version}" />
+			<bundleref name="org.jdom:jdom2" version="${jdom2.version}" />
+		</dependencies>
+		<export>mpicbg.spim.data.*</export>
 	</bundle>
 </bundlegroup>

--- a/autogen/bundlegroups/sc.fiji.xml
+++ b/autogen/bundlegroups/sc.fiji.xml
@@ -1,0 +1,22 @@
+
+<!-- fiji bundles-->
+<bundlegroup name="sc.fiji">
+	<!-- Bigdataviewer bundle -->
+	<bundle name="bigdataviewer-core" version="${bigdataviewer-core.version}">
+		<artifacts>
+			<artifact>
+				<group>sc.fiji</group>
+				<id>bigdataviewer-core</id>
+				<version>${bigdataviewer-core.version}</version>
+			</artifact>
+		</artifacts>
+		<dependencies>
+			<bundleref name="net.imglib2:imglib2" version="${imglib2.version}" />
+			<bundleref name="net.imglib2:imglib2-roi" version="${imglib2-roi.version}" />
+			<bundleref name="net.imglib2:imglib2-realtransform" version="${imglib2-realtransform.version}" />
+			<bundleref name="net.imglib2:imglib2-ui" version="${imglib2-ui.version}" />
+			<bundleref name="net.imglib2:imglib2-algorithm" version="${imglib2-algorithm.version}" />
+		</dependencies>
+		<export>bdv.*, net.imglib2.img.basictypeaccess.volatiles.*, net.imglib2.interpolation.randomaccess.*, net.imglib2.type.volatiles.*</export>
+	</bundle>
+</bundlegroup>

--- a/autogen/pom.xml
+++ b/autogen/pom.xml
@@ -24,6 +24,7 @@
 		<scijava.enforce.skip />
 		<jep.version>2.4.2</jep.version>
 		<fifesoft.version>2.5.8</fifesoft.version>
+		<bigdataviewer-core.version>2.2.1</bigdataviewer-core.version>
 
 		<!-- Deprecated package definitions. We shouldn't base on snapshots and 
 			knip-ops should be gone soon -->

--- a/autogen/pom.xml
+++ b/autogen/pom.xml
@@ -24,11 +24,14 @@
 		<scijava.enforce.skip />
 		<jep.version>2.4.2</jep.version>
 		<fifesoft.version>2.5.8</fifesoft.version>
+
+		<!-- bigdataviewer versions -->
 		<bigdataviewer-core.version>2.2.1</bigdataviewer-core.version>
+		<spim_data.version>2.0.1</spim_data.version>
+		<scijava-ui-behaviour.version>1.0.2</scijava-ui-behaviour.version>
 
 		<!-- Deprecated package definitions. We shouldn't base on snapshots and 
 			knip-ops should be gone soon -->
-
 		<knip-tmp-imglib2-ops.version>0.4.0</knip-tmp-imglib2-ops.version>
 		<knip-trackmate-fork.version>2.7.3</knip-trackmate-fork.version>
 

--- a/autogen/update-site.xml
+++ b/autogen/update-site.xml
@@ -27,5 +27,6 @@
 	<include>bundlegroups/org.apache.xml</include>
 	<include>bundlegroups/com.google.guava.xml</include>
 	<include>bundlegroups/xml-apis.xml</include>
+	<include>bundlegroups/sc.fiji.xml</include>
 
 </updatesite>

--- a/autogen/update-site.xml
+++ b/autogen/update-site.xml
@@ -28,5 +28,6 @@
 	<include>bundlegroups/com.google.guava.xml</include>
 	<include>bundlegroups/xml-apis.xml</include>
 	<include>bundlegroups/sc.fiji.xml</include>
+	<include>bundlegroups/org.jdom.xml</include>
 
 </updatesite>


### PR DESCRIPTION
Adds a bundlegroup for fiji projects, currently only housing the bigdataviewer.
Also adds bundles for shared dependencies.