### PR TITLE
Timestamped builds

### DIFF
--- a/autogen/groovy/BuildFilesGenerator.groovy
+++ b/autogen/groovy/BuildFilesGenerator.groovy
@@ -463,7 +463,7 @@ def main() {
 			bundle-> dependencies += ("\t\t<dependency> \n"
 				+ "\t\t\t<groupId>" + data.site.group + "</groupId>\n"
 				+ "\t\t\t<artifactId>" + bundle.name + "</artifactId>\n"
-				+ "\t\t\t<version>" + bundle.version + ".\${ktimestamp}" +"</version>\n\t\t</dependency>\n"
+				+ "\t\t\t<version>" + bundle.version + ".\${buildstamp}" +"</version>\n\t\t</dependency>\n"
 				)
 				bundles += "\t<bundle id=\"" + bundle.name + "\" version=\"0.0.0\" />\n"
 		}

--- a/autogen/groovy/BuildFilesGenerator.groovy
+++ b/autogen/groovy/BuildFilesGenerator.groovy
@@ -431,7 +431,7 @@ def main() {
 				bundleTemplate.writeFile(buildDir + File.separator + group.name + File.separator + bundle.name, "pom.xml", [
 					"BUNDLE_GROUP":bundle.group.name,
 					"BUNDLE_NAME":bundle.name,
-					"BUNDLE_VERSION":Helper.resolveProperty(project, bundle.version, true),
+					"BUNDLE_VERSION":Helper.resolveProperty(project, bundle.version, true) + ".\${timestamp}",
 					"BUNDLE_INSTRUCTIONS":"<instructions>\n" + requireBundles + bundle.instructions + "</instructions>",
 					"BUNDLE_EXPORT":bundle.exports,
 					"BUNDLE_IMPORT":bundle.imports,
@@ -442,6 +442,7 @@ def main() {
 			
 			bundleGroupTemplate.writeFile(buildDir + File.separator + group.name, "pom.xml", group_map)
 		}
+		parentModules += "<module>knip.buildversion</module>\n"
 		parentTemplate.writeFile(buildDir, "pom.xml", ["MODULES":parentModules+"\t</modules>","REPOSITORIES":parentRepos+"\t</repositories>"])
 	} catch(IOException e) {
 		fail("Could not open template file '" + p_filename + "'.")
@@ -462,7 +463,7 @@ def main() {
 			bundle-> dependencies += ("\t\t<dependency> \n"
 				+ "\t\t\t<groupId>" + data.site.group + "</groupId>\n"
 				+ "\t\t\t<artifactId>" + bundle.name + "</artifactId>\n"
-				+ "\t\t\t<version>" + bundle.version + "</version>\n\t\t</dependency>\n"
+				+ "\t\t\t<version>" + bundle.version + ".\${ktimestamp}" +"</version>\n\t\t</dependency>\n"
 				)
 				bundles += "\t<bundle id=\"" + bundle.name + "\" version=\"0.0.0\" />\n"
 		}
@@ -477,7 +478,7 @@ def main() {
 	
 	def Template categoryTemplate = new Template(templateDir + File.separator + categoryTemplateFilename)
 	categoryTemplate.writeFile(buildDir + File.separator + "update-site", "category.xml", ["BUNDLES":bundles])
-	
+
 	log.info("> SUCCESS!")
 }
 main()

--- a/autogen/pom.xml
+++ b/autogen/pom.xml
@@ -89,6 +89,29 @@
 			</plugin>
 
 			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.7</version>
+				<executions>
+					<execution>
+						<id>copy-resources</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${pom.basedir}/../target/knip.buildversion</outputDirectory>
+							<resources>
+								<resource>
+									<directory>${pom.basedir}/templates/knip.buildversion</directory>
+									<filtering>false</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
 				<groupId>org.eclipse.m2e</groupId>
 				<artifactId>lifecycle-mapping</artifactId>
 				<version>1.0.0</version>

--- a/autogen/templates/knip.buildversion/groovy/Replacer.groovy
+++ b/autogen/templates/knip.buildversion/groovy/Replacer.groovy
@@ -8,10 +8,6 @@ import groovy.xml.DOMBuilder
 import groovy.xml.dom.DOMCategory
 import groovy.util.logging.Slf4j
 
-/**
- * Globals
- */
-def String VERSION = "0.0.1"
 
 
 /**
@@ -19,7 +15,7 @@ def String VERSION = "0.0.1"
  */
 def main() {
 	
-	log.info("--- Version Injector Version " + VERSION + "---")
+	log.info("--- Buildstamp Injector ---")
 
 	def targetFile = properties['targetFile']
 	if (targetFile == null) {
@@ -31,7 +27,7 @@ def main() {
 		fail("Property 'buildStamp' undefined.")
 	}
 
-	ant.replace(file: targetFile, token: "%(BUILDSTAMP)", value: "<ktimestamp>" + timeStamp +"</ktimestamp>")
+	ant.replace(file: targetFile, token: "%(BUILDSTAMP)", value: "<buildstamp>" + timeStamp +"</buildstamp>")
 }
 main()
 

--- a/autogen/templates/knip.buildversion/groovy/Replacer.groovy
+++ b/autogen/templates/knip.buildversion/groovy/Replacer.groovy
@@ -1,0 +1,37 @@
+/**
+ * BuildFilesGenerator - generates maven poms and category.xml from an update-site.xml.
+ *
+ * @author Jonathan Hale (University of Konstanz)
+ */
+
+import groovy.xml.DOMBuilder
+import groovy.xml.dom.DOMCategory
+import groovy.util.logging.Slf4j
+
+/**
+ * Globals
+ */
+def String VERSION = "0.0.1"
+
+
+/**
+ * Main function
+ */
+def main() {
+	
+	log.info("--- Version Injector Version " + VERSION + "---")
+
+	def targetFile = properties['targetFile']
+	if (targetFile == null) {
+		fail("Property 'targetFile' undefined.")
+	}
+
+	def timeStamp = properties['buildStamp']
+	if (timeStamp == null) {
+		fail("Property 'buildStamp' undefined.")
+	}
+
+	ant.replace(file: targetFile, token: "%(BUILDSTAMP)", value: "<ktimestamp>" + timeStamp +"</ktimestamp>")
+}
+main()
+

--- a/autogen/templates/knip.buildversion/pom.xml
+++ b/autogen/templates/knip.buildversion/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.knime.knip</groupId>
+		<artifactId>knip-externals</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<name>KNIP External Build version writer</name>
+
+	<artifactId>buildversion</artifactId>
+	<version>1.0.0</version>
+	<packaging>jar</packaging>
+
+<build>
+  <resources>
+    <resource>
+      <directory>src/main/resources</directory>
+      <filtering>true</filtering>
+      <includes>
+        <include>**/version.properties</include>
+      </includes>
+    </resource>
+    <resource>
+      <directory>src/main/resources</directory>
+      <filtering>false</filtering>
+      <excludes>
+        <exclude>**/version.properties</exclude>
+      </excludes>
+    </resource>
+  </resources>
+   <plugins>
+	  <plugin>
+		  <groupId>org.codehaus.gmaven</groupId>
+		  <artifactId>groovy-maven-plugin</artifactId>
+		  <version>2.0</version>
+		  <executions>
+			  <execution>
+				  <phase>process-resources</phase>
+				  <goals>
+					  <goal>execute</goal>
+				  </goals>
+				  <configuration>
+					  <properties>
+						<targetFile>${pom.basedir}/../update-site/pom.xml</targetFile>
+						<buildStamp>${timestamp}</buildStamp>
+					  </properties>
+					  <source>${pom.basedir}/groovy/Replacer.groovy</source>
+				  </configuration>
+			  </execution>
+		  </executions>
+	  </plugin>
+   </plugins>
+</build>
+
+</project>
+

--- a/autogen/templates/knip.buildversion/src/main/resources/version.properties
+++ b/autogen/templates/knip.buildversion/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+ktimestamp=${timestamp}

--- a/autogen/templates/parent_template.xml
+++ b/autogen/templates/parent_template.xml
@@ -18,8 +18,9 @@
 
 	<properties>
 		<felix-plugin.version>2.4.0</felix-plugin.version>
+	   	<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+		<timestamp>${maven.build.timestamp}</timestamp>
 	</properties>
-
 
 	%(MODULES)
 

--- a/autogen/templates/updatesite_template.xml
+++ b/autogen/templates/updatesite_template.xml
@@ -4,6 +4,7 @@
 
 	<properties>
 		<tycho-version>0.22.0</tycho-version>
+		%(BUILDSTAMP)
 	</properties>
 
 	<parent>


### PR DESCRIPTION
Adds a timestamp to each built plugin: e.g. ``imglib2 2.3.0.201604282053``

This results in each jenkins run creating all new plugin versions, forcing eclipse to update all plugins when the target platform is refreshed. Now all updates to plugin configurations will get updated even if the plugin version itself is not changed.

