### PR TITLE
Updated Dependencies

### DIFF
--- a/autogen/bundlegroups/org.scijava.xml
+++ b/autogen/bundlegroups/org.scijava.xml
@@ -125,7 +125,7 @@
 	</bundle>
 
 	<!-- SciJava UI Behaviour-->
-	<bundle name="scijava-ui-behaviour" version="${ui-behaviour.version}">
+	<bundle name="ui-behaviour" version="${ui-behaviour.version}">
 		<artifacts>
 			<artifact>
 				<group>org.scijava</group>

--- a/autogen/bundlegroups/sc.fiji.xml
+++ b/autogen/bundlegroups/sc.fiji.xml
@@ -17,7 +17,9 @@
 			<bundleref name="net.imglib2:imglib2-ui" version="${imglib2-ui.version}" />
 			<bundleref name="net.imglib2:imglib2-algorithm" version="${imglib2-algorithm.version}" />
 			<bundleref name="com.google.code.gson:gson" version="${gson.version}" />
-		</dependencies>
+	                <bundleref name="net.sf.trove4j:trove4j" version="${trove4j.version}" />
+			<bundleref name="org.scijava:ui-behaviour" version="${ui-behaviour.version}" />
+	</dependencies>
 		<export>bdv.*, net.imglib2.img.basictypeaccess.volatiles.*, net.imglib2.interpolation.randomaccess.*, net.imglib2.type.volatiles.*, net.imglib2.display.*</export>
 	</bundle>
 
@@ -56,6 +58,8 @@
 			<bundleref name="net.imglib2:imglib2-ui" version="${imglib2-ui.version}" />
 			<bundleref name="net.imglib2:imglib2-algorithm" version="${imglib2-algorithm.version}" />
 			<bundleref name="com.google.code.gson:gson" version="${gson.version}" />
+			<bundleref name="net.sf.trove4j:trove4j" version="${trove4j.version}" />		
+			<bundleref name="org.scijava:ui-behaviour" version="${ui-behaviour.version}" />
 		</dependencies>
 		<export>bdv.util.*</export>
 	</bundle>


### PR DESCRIPTION
This Pullrequest contains two small changes to get bdv-vistools to build and run:

Changed dependencies in order to be able to build bdv-vistools
Renamed scijava-ui-behaviour to ui-behaviour in accordance with the scijava naming scheme