### PR TITLE
Only export packages which belong to a bundle

### DIFF
--- a/autogen/bundlegroups/com.google.xml
+++ b/autogen/bundlegroups/com.google.xml
@@ -8,7 +8,7 @@
 				<version>${guava.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>com.google.common.*</export>
 	</bundle>
 	<bundle name="gson" version="${gson.version}">
 		<artifacts>
@@ -18,6 +18,6 @@
 				<version>${gson.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>com.google.gson.*</export>
 	</bundle>
 </bundlegroup>

--- a/autogen/bundlegroups/com.miglayout.xml
+++ b/autogen/bundlegroups/com.miglayout.xml
@@ -8,7 +8,7 @@
 				<version>${miglayout.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>net.miginfocom.layout.*</export>
 	</bundle>
 	<bundle name="miglayout-swing" version="${miglayout-swing.version}">
 		<artifacts>
@@ -18,7 +18,7 @@
 				<version>${miglayout-swing.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>net.miginfocom.swing.*</export>
 	</bundle>
 
 </bundlegroup>

--- a/autogen/bundlegroups/gov.nist.math.xml
+++ b/autogen/bundlegroups/gov.nist.math.xml
@@ -8,6 +8,6 @@
 				<version>${jama.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>Jama.*</export>
 	</bundle>
 </bundlegroup>

--- a/autogen/bundlegroups/net.imagej.xml
+++ b/autogen/bundlegroups/net.imagej.xml
@@ -140,13 +140,12 @@
 			<bundleref name="org.scijava:scijava-ui-swing" version="${scijava-ui-swing.version}" />
 			<bundleref name="net.imagej:imagej-ui-awt" version="${imagej-ui-awt.version}" />
 			<bundleref name="org.scijava:scripting-java" version="${scripting-java.version}" />
-			<bundleref name="com.miglayout:miglayout" version="${miglayout.version}" />
 			<bundleref name="com.miglayout:miglayout-swing" version="${miglayout-swing.version}" />
 			<bundleref name="net.sf.trove4j:trove4j" version="${trove4j.version}" />
 			<bundleref name="com.fifesoft:autocomplete" version="${fifesoft.version}" isExternal="true" />
 		    <bundleref name="com.fifesoft:languagesupport" version="${fifesoft.version}" isExternal="true" />
 	        <bundleref name="com.fifesoft:rsyntaxtextarea" version="${fifesoft.version}" isExternal="true" />
 		</dependencies>
-		<export>net.imagej.ui.swing.*, org.*</export>
+		<export>net.imagej.ui.swing.*</export>
 	</bundle>
 </bundlegroup>

--- a/autogen/bundlegroups/net.sf.trove4j.xml
+++ b/autogen/bundlegroups/net.sf.trove4j.xml
@@ -8,6 +8,6 @@
 				<version>${trove4j.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>gnu.trove.*</export>
 	</bundle>
 </bundlegroup>

--- a/autogen/bundlegroups/org.apache.xml
+++ b/autogen/bundlegroups/org.apache.xml
@@ -8,7 +8,7 @@
 				<version>${commons-collections.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>org.apache.commons.collections.*</export>
 	</bundle>
 	<bundle name="commons-math3" version="${commons-math3.version}">
 		<artifacts>
@@ -18,6 +18,6 @@
 				<version>${commons-math3.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>org.apache.commons.math3.*</export>
 	</bundle>
 </bundlegroup>

--- a/autogen/bundlegroups/org.jdom.xml
+++ b/autogen/bundlegroups/org.jdom.xml
@@ -10,7 +10,7 @@
 				<version>${jdom2.version}</version>
 			</artifact>
 		</artifacts>
-		<export>jdom2.*</export>
+		<export>org.jdom2.*</export>
 	</bundle>
 
 </bundlegroup>

--- a/autogen/bundlegroups/org.kohsuke.xml
+++ b/autogen/bundlegroups/org.kohsuke.xml
@@ -8,6 +8,6 @@
 				<version>${args4j.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>org.kohsuke.args4j.*</export>
 	</bundle>
 </bundlegroup>

--- a/autogen/bundlegroups/org.scijava.xml
+++ b/autogen/bundlegroups/org.scijava.xml
@@ -10,7 +10,7 @@
 				<version>${jep.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>org.nfunk.jep.*, org.lsmp.djep.*</export>
 		<dependencies>
 			<bundleref name="gov.nist.math:jama" version="${jama.version}" />
 		</dependencies>
@@ -115,7 +115,8 @@
 				<version>${scijava-ui-swing.version}</version>
 			</artifact>
 		</artifacts>
-		<export>!com.fifesoft.*, *</export>
+		<!-- <export>!com.fifesoft.*, *</export> -->
+		<export>org.scijava.ui.swing.*</export>
 		<dependencies>
 			<bundleref name="org.scijava:scijava-common" version="${scijava-common.version}" />
 			<bundleref name="org.scijava:scijava-ui-awt" version="${scijava-ui-awt.version}" />

--- a/autogen/bundlegroups/org.slf4j.xml
+++ b/autogen/bundlegroups/org.slf4j.xml
@@ -8,7 +8,7 @@
 				<version>${slf4j-api.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>org.slf4j.*</export>
 	</bundle>
 	<bundle name="slf4j-log4j12" version="${slf4j-log4j12.version}">
 		<artifacts>
@@ -18,6 +18,6 @@
 				<version>${slf4j-log4j12.version}</version>
 			</artifact>
 		</artifacts>
-		<export>*</export>
+		<export>org.slf4j.*</export>
 	</bundle>
 </bundlegroup>

--- a/autogen/bundlegroups/sc.fiji.xml
+++ b/autogen/bundlegroups/sc.fiji.xml
@@ -58,7 +58,7 @@
 			<bundleref name="net.imglib2:imglib2-ui" version="${imglib2-ui.version}" />
 			<bundleref name="net.imglib2:imglib2-algorithm" version="${imglib2-algorithm.version}" />
 			<bundleref name="com.google.code.gson:gson" version="${gson.version}" />
-			<bundleref name="net.sf.trove4j:trove4j" version="${trove4j.version}" />		
+			<bundleref name="net.sf.trove4j:trove4j" version="${trove4j.version}" />
 			<bundleref name="org.scijava:ui-behaviour" version="${ui-behaviour.version}" />
 		</dependencies>
 		<export>bdv.util.*</export>


### PR DESCRIPTION
Using ``<export>*</export>`` leads to all packages of a bundle's dependencies
to be exported as well, potentially clashing with bundles using "import package".