### PR TITLE
Update SCIFIO version

### DIFF
--- a/autogen/pom.xml
+++ b/autogen/pom.xml
@@ -53,8 +53,9 @@
 			knip-ops should be gone soon -->
 		<knip-tmp-imglib2-ops.version>0.4.1</knip-tmp-imglib2-ops.version>
 		<knip-trackmate-fork.version>2.7.3</knip-trackmate-fork.version>
-        <imglib2-realtransform.version>2.0.99</imglib2-realtransform.version>
-        <imglib2.version>5.4.0</imglib2.version>
+		<imglib2-realtransform.version>2.0.99</imglib2-realtransform.version>
+		<imglib2.version>5.4.0</imglib2.version>
+		<scifio.version>0.37.1</scifio.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
This temporarily bumps the `scifio` version to 0.37.1 to fix ICS/IDS dataset loading. Can be removed once `pom-scijava` is updated to manage the same or a newer version.

See https://github.com/scifio/scifio/pull/376.